### PR TITLE
Add Copy next notes list command with tree and cycle support

### DIFF
--- a/lib/commands.ts
+++ b/lib/commands.ts
@@ -239,12 +239,12 @@ export async function copyNextNotesListCommand(app: App) {
 
     function dfs(current: TFile, depth: number) {
         if (visited.has(current.path)) {
-            nodes.push({ file: current, depth, isCycle: true });
             return;
         }
         
         visited.add(current.path);
-        nodes.push({ file: current, depth, isCycle: false });
+        const nodeMeta: NodeMeta = { file: current, depth, isCycle: false };
+        nodes.push(nodeMeta);
 
         const nextNotes = getNextNotes(app, current);
         if (nextNotes.length > 1) {
@@ -252,6 +252,10 @@ export async function copyNextNotesListCommand(app: App) {
         }
 
         for (const nextNote of nextNotes) {
+            if (visited.has(nextNote.path)) {
+                nodeMeta.isCycle = true;
+                continue;
+            }
             dfs(nextNote, depth + 1);
         }
     }

--- a/lib/commands.ts
+++ b/lib/commands.ts
@@ -1,7 +1,7 @@
 import { App, TFile, Notice } from "obsidian";
 import { ConfirmModal } from "./ConfirmModal";
 import { NextNoteSuggestModal } from "./NextNoteSuggestModal";
-import { getActiveFile, getPreviousNote, getNextNotes, detachNote, setPreviousProperty, findLastNote, findFirstNote, isOnSamePath } from "./obsidian";
+import { getActiveFile, getPreviousNote, getNextNotes, getNextNotesWithCache, buildReverseCache, detachNote, setPreviousProperty, findLastNote, findFirstNote, isOnSamePath } from "./obsidian";
 
 export async function goToPreviousNoteCommand(app: App) {
     const file = getActiveFile(app);
@@ -237,6 +237,8 @@ export async function copyNextNotesListCommand(app: App) {
     const visited = new Set<string>();
     let hasBranches = false;
 
+    const reverseCache = buildReverseCache(app);
+
     function dfs(current: TFile, depth: number) {
         if (visited.has(current.path)) {
             return;
@@ -246,7 +248,7 @@ export async function copyNextNotesListCommand(app: App) {
         const nodeMeta: NodeMeta = { file: current, depth, isCycle: false };
         nodes.push(nodeMeta);
 
-        const nextNotes = getNextNotes(app, current);
+        const nextNotes = getNextNotesWithCache(app, current, reverseCache);
         if (nextNotes.length > 1) {
             hasBranches = true;
         }

--- a/lib/commands.ts
+++ b/lib/commands.ts
@@ -227,25 +227,44 @@ export async function copyNextNotesListCommand(app: App) {
         return;
     }
 
-    const list: string[] = [];
+    interface NodeMeta {
+        file: TFile;
+        depth: number;
+        isCycle: boolean;
+    }
+
+    const nodes: NodeMeta[] = [];
     const visited = new Set<string>();
-    const queue: TFile[] = [file];
+    let hasBranches = false;
 
-    while (queue.length > 0) {
-        const current = queue.shift()!;
+    function dfs(current: TFile, depth: number) {
         if (visited.has(current.path)) {
-            continue; // Cycle detected
+            nodes.push({ file: current, depth, isCycle: true });
+            return;
         }
+        
         visited.add(current.path);
-
-        list.push(`- [[${current.basename}]]`);
+        nodes.push({ file: current, depth, isCycle: false });
 
         const nextNotes = getNextNotes(app, current);
-        // Add next notes to the queue to traverse them
-        queue.push(...nextNotes);
+        if (nextNotes.length > 1) {
+            hasBranches = true;
+        }
+
+        for (const nextNote of nextNotes) {
+            dfs(nextNote, depth + 1);
+        }
     }
+
+    dfs(file, 0);
+
+    const list = nodes.map(node => {
+        const indent = hasBranches ? "\t".repeat(node.depth) : "";
+        const suffix = node.isCycle ? " 🔄" : "";
+        return `${indent}- [[${node.file.basename}]]${suffix}`;
+    });
 
     const text = list.join("\n");
     await navigator.clipboard.writeText(text);
-    new Notice("Copied next notes list to clipboard.");
+    new Notice(hasBranches ? "Copied next notes tree to clipboard." : "Copied next notes list to clipboard.");
 }

--- a/lib/commands.ts
+++ b/lib/commands.ts
@@ -220,3 +220,32 @@ function getSortedMarkdownFiles(app: App): TFile[] {
         return a.basename.localeCompare(b.basename);
     });
 }
+
+export async function copyNextNotesListCommand(app: App) {
+    const file = getActiveFile(app);
+    if (!file) {
+        return;
+    }
+
+    const list: string[] = [];
+    const visited = new Set<string>();
+    const queue: TFile[] = [file];
+
+    while (queue.length > 0) {
+        const current = queue.shift()!;
+        if (visited.has(current.path)) {
+            continue; // Cycle detected
+        }
+        visited.add(current.path);
+
+        list.push(`- [[${current.basename}]]`);
+
+        const nextNotes = getNextNotes(app, current);
+        // Add next notes to the queue to traverse them
+        queue.push(...nextNotes);
+    }
+
+    const text = list.join("\n");
+    await navigator.clipboard.writeText(text);
+    new Notice("Copied next notes list to clipboard.");
+}

--- a/lib/obsidian.ts
+++ b/lib/obsidian.ts
@@ -125,7 +125,7 @@ export async function setPreviousProperty(app: App, file: TFile, previousLink: s
   });
 }
 
-function buildReverseCache(app: App): Record<string, string[]> {
+export function buildReverseCache(app: App): Record<string, string[]> {
   const resolvedLinks = app.metadataCache.resolvedLinks;
   const cache: Record<string, string[]> = {};
 

--- a/main.ts
+++ b/main.ts
@@ -7,7 +7,8 @@ import {
   detachNoteCommand,
   insertNoteToLastCommand,
   insertNoteCommand,
-  insertNoteToFirstCommand
+  insertNoteToFirstCommand,
+  copyNextNotesListCommand
 } from "./lib/commands";
 
 export default class PreviousRiverPlugin extends Plugin {
@@ -58,6 +59,12 @@ export default class PreviousRiverPlugin extends Plugin {
       id: "insert-note-to-first",
       name: "Insert note to first",
       callback: () => insertNoteToFirstCommand(this.app),
+    });
+
+    this.addCommand({
+      id: "copy-next-notes-list",
+      name: "Copy next notes list",
+      callback: () => copyNextNotesListCommand(this.app),
     });
   }
 }


### PR DESCRIPTION
# Overview
Added the `Copy next notes list` command, which allows users to copy the downstream (`next`) notes chain starting from the currently active note to the clipboard as a Markdown list.

# Background
Previously, users could traverse notes using the `go-to-next-note` command, but there was no built-in way to visualize the entire path or export the connected notes. This PR makes it easy to visualize and export downstream note chains.

# Usage
1. Open the starting note.
2. Run `Copy next notes list` from the command palette.
3. The result is copied to your clipboard, ready to be pasted anywhere.