### PR TITLE
Add command to export the next notes tree to a Canvas file

### DIFF
--- a/lib/canvas.ts
+++ b/lib/canvas.ts
@@ -1,0 +1,26 @@
+export interface CanvasNode {
+    id: string;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    type: "file";
+    file: string;
+}
+
+export interface CanvasEdge {
+    id: string;
+    fromNode: string;
+    fromSide: "top" | "right" | "bottom" | "left";
+    toNode: string;
+    toSide: "top" | "right" | "bottom" | "left";
+}
+
+export interface CanvasData {
+    nodes: CanvasNode[];
+    edges: CanvasEdge[];
+}
+
+export function randomId(): string {
+    return Math.random().toString(36).substring(2, 18);
+}

--- a/lib/commands.ts
+++ b/lib/commands.ts
@@ -308,7 +308,7 @@ export async function exportNextNotesToCanvasCommand(app: App) {
             x: depth * 400,
             y: y,
             width: 300,
-            height: 100
+            height: 250
         });
 
         if (y > maxUsedY) {
@@ -323,7 +323,7 @@ export async function exportNextNotesToCanvasCommand(app: App) {
                 childY = y;
                 first = false;
             } else {
-                maxUsedY += 150;
+                maxUsedY += 300;
                 childY = maxUsedY;
             }
 

--- a/lib/commands.ts
+++ b/lib/commands.ts
@@ -290,8 +290,9 @@ export async function exportNextNotesToCanvasCommand(app: App) {
     const reverseCache = buildReverseCache(app);
 
     let maxUsedY = 0;
+    const MAX_COLUMNS = 5;
 
-    function dfs(current: TFile, depth: number, y: number): string {
+    function dfs(current: TFile, col: number, y: number, direction: number): string {
         const existingNodeId = fileToNodeId.get(current.path);
         if (existingNodeId) {
             // Already visited this node in the graph, return its ID to link the edge
@@ -305,7 +306,7 @@ export async function exportNextNotesToCanvasCommand(app: App) {
             id: nodeId,
             type: "file",
             file: current.path,
-            x: depth * 400,
+            x: col * 400,
             y: y,
             width: 300,
             height: 250
@@ -318,29 +319,51 @@ export async function exportNextNotesToCanvasCommand(app: App) {
         const nextNotes = getNextNotesWithCache(app, current, reverseCache);
         let first = true;
         for (const nextNote of nextNotes) {
-            let childY: number;
+            let nextCol = col + direction;
+            let nextY = y;
+            let nextDir = direction;
+
             if (first) {
-                childY = y;
                 first = false;
             } else {
                 maxUsedY += 300;
-                childY = maxUsedY;
+                nextY = maxUsedY;
             }
 
-            const childId = dfs(nextNote, depth + 1, childY);
+            if (nextCol >= MAX_COLUMNS) {
+                nextCol = MAX_COLUMNS - 1;
+                nextY += 300;
+                nextDir = -1;
+                if (nextY > maxUsedY) maxUsedY = nextY;
+            } else if (nextCol < 0) {
+                nextCol = 0;
+                nextY += 300;
+                nextDir = 1;
+                if (nextY > maxUsedY) maxUsedY = nextY;
+            }
+
+            let fromSide: CanvasEdge["fromSide"] = direction === 1 ? "right" : "left";
+            let toSide: CanvasEdge["toSide"] = direction === 1 ? "left" : "right";
+
+            if (nextCol === col) {
+                fromSide = "bottom";
+                toSide = "top";
+            }
+
+            const childId = dfs(nextNote, nextCol, nextY, nextDir);
             edges.push({
                 id: randomId(),
                 fromNode: nodeId,
-                fromSide: "right",
+                fromSide: fromSide,
                 toNode: childId,
-                toSide: "left"
+                toSide: toSide
             });
         }
 
         return nodeId;
     }
 
-    dfs(file, 0, 0);
+    dfs(file, 0, 0, 1);
 
     const canvasData: CanvasData = { nodes, edges };
     const canvasJson = JSON.stringify(canvasData, null, 2);

--- a/lib/commands.ts
+++ b/lib/commands.ts
@@ -2,6 +2,7 @@ import { App, TFile, Notice } from "obsidian";
 import { ConfirmModal } from "./ConfirmModal";
 import { NextNoteSuggestModal } from "./NextNoteSuggestModal";
 import { getActiveFile, getPreviousNote, getNextNotes, getNextNotesWithCache, buildReverseCache, detachNote, setPreviousProperty, findLastNote, findFirstNote, isOnSamePath } from "./obsidian";
+import { CanvasData, CanvasEdge, CanvasNode, randomId } from "./canvas";
 
 export async function goToPreviousNoteCommand(app: App) {
     const file = getActiveFile(app);
@@ -273,4 +274,90 @@ export async function copyNextNotesListCommand(app: App) {
     const text = list.join("\n");
     await navigator.clipboard.writeText(text);
     new Notice(hasBranches ? "Copied next notes tree to clipboard." : "Copied next notes list to clipboard.");
+}
+
+export async function exportNextNotesToCanvasCommand(app: App) {
+    const file = getActiveFile(app);
+    if (!file) {
+        return;
+    }
+
+    const nodes: CanvasNode[] = [];
+    const edges: CanvasEdge[] = [];
+    
+    // filePath -> canvas nodeId
+    const fileToNodeId = new Map<string, string>();
+    const reverseCache = buildReverseCache(app);
+
+    let maxUsedY = 0;
+
+    function dfs(current: TFile, depth: number, y: number): string {
+        const existingNodeId = fileToNodeId.get(current.path);
+        if (existingNodeId) {
+            // Already visited this node in the graph, return its ID to link the edge
+            return existingNodeId;
+        }
+
+        const nodeId = randomId();
+        fileToNodeId.set(current.path, nodeId);
+
+        nodes.push({
+            id: nodeId,
+            type: "file",
+            file: current.path,
+            x: depth * 400,
+            y: y,
+            width: 300,
+            height: 100
+        });
+
+        if (y > maxUsedY) {
+            maxUsedY = y;
+        }
+
+        const nextNotes = getNextNotesWithCache(app, current, reverseCache);
+        let first = true;
+        for (const nextNote of nextNotes) {
+            let childY: number;
+            if (first) {
+                childY = y;
+                first = false;
+            } else {
+                maxUsedY += 150;
+                childY = maxUsedY;
+            }
+
+            const childId = dfs(nextNote, depth + 1, childY);
+            edges.push({
+                id: randomId(),
+                fromNode: nodeId,
+                fromSide: "right",
+                toNode: childId,
+                toSide: "left"
+            });
+        }
+
+        return nodeId;
+    }
+
+    dfs(file, 0, 0);
+
+    const canvasData: CanvasData = { nodes, edges };
+    const canvasJson = JSON.stringify(canvasData, null, 2);
+
+    let canvasPath = `${file.basename} - Next Notes.canvas`;
+    if (file.parent && file.parent.path !== '/') {
+        canvasPath = `${file.parent.path}/${canvasPath}`;
+    }
+
+    let finalPath = canvasPath;
+    let increment = 0;
+    while (app.vault.getAbstractFileByPath(finalPath)) {
+        increment++;
+        finalPath = canvasPath.replace('.canvas', ` ${increment}.canvas`);
+    }
+
+    const newCanvasFile = await app.vault.create(finalPath, canvasJson);
+    await app.workspace.getLeaf().openFile(newCanvasFile);
+    new Notice(`Created canvas: ${newCanvasFile.basename}`);
 }

--- a/main.ts
+++ b/main.ts
@@ -8,7 +8,8 @@ import {
   insertNoteToLastCommand,
   insertNoteCommand,
   insertNoteToFirstCommand,
-  copyNextNotesListCommand
+  copyNextNotesListCommand,
+  exportNextNotesToCanvasCommand
 } from "./lib/commands";
 
 export default class PreviousRiverPlugin extends Plugin {
@@ -65,6 +66,12 @@ export default class PreviousRiverPlugin extends Plugin {
       id: "copy-next-notes-list",
       name: "Copy next notes list",
       callback: () => copyNextNotesListCommand(this.app),
+    });
+
+    this.addCommand({
+      id: "export-next-notes-to-canvas",
+      name: "Export next notes to canvas",
+      callback: () => exportNextNotesToCanvasCommand(this.app),
     });
   }
 }


### PR DESCRIPTION
Add a new command to export a network of "Next Notes" (notes connected sequentially via the `previous` property) as an Obsidian Canvas (`.canvas`) file. 
