### PR TITLE
1.1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,12 @@
 # History
 
+## 1.1.0 (2026-05-14)
+- **Next button**: Add a "Next" button to the right side of the `previous` property row within Obsidian's native Properties view.
+- **Duplicate next note**: Add a command to duplicate the currently active note and automatically set the new note's `previous` property to point back to the original note.
+- **Set ROOT**: Add a command to quickly set the `previous` property of the active file to `ROOT`.
+- **Fix floating promise lint error**: Fix a TypeScript linting error in `ExportFilterModal` by explicitly handling an unhandled promise invocation.
+- **Translate technical docs**: Translate the Japanese technical documentation (`docs/ja/`) into English.
+
 ## 1.0.0 (2026-04-30)
 - **Stable Release**: Official 1.0.0 release. 
 - **Documentation & Safety**: Finalized and documented the `isAncestor` / `isOnSamePath` safety algorithms that prevent cycle references and protect note graph integrity.

--- a/docs/en/002_find_last_note_optimization.md
+++ b/docs/en/002_find_last_note_optimization.md
@@ -1,0 +1,110 @@
+# Optimization of Searching for the Last Note in Previous River
+
+## Purpose
+
+There was a problem where executing search processes like `findLastNote()` on a group of notes with a deep link hierarchy (e.g., depth 10,000) would block (freeze) the application for a long time. This algorithm reduces the computational complexity from $O(V \times D)$ to $O(E + D)$ and optimizes the search process ($V$: total number of notes, $E$: total number of edges, $D$: search depth).
+
+## Terminology
+
+- **Forward Cache**: The normal access method, reading a note's own properties (frontmatter).
+- **Reverse Cache**: An associative array (map) that pre-builds all references from destination (parent) to source (child) at once.
+
+## Design Philosophy
+
+To eliminate the bottleneck of the search process, the following methods were evaluated, and the final architecture was decided.
+
+| Consideration | Adopted Idea | Rejected Idea | Reason |
+|---|---|---|---|
+| Getting next notes | Batch pre-building of cache (`buildReverseCache`) | Scanning all files every loop (`Object.entries`) | Because scanning all files using `Object.entries` causes Garbage Collection (GC) overhead from array creation and has a computational complexity of $O(V \times D)$. |
+| Getting backlinks | Iterating `app.metadataCache.resolvedLinks` with `for...in` | Using `app.metadataCache.getBacklinksForFile()` | Because the unofficial API `getBacklinksForFile()` dynamically creates `ReferenceCache` objects internally, which caused significant memory allocation overhead. |
+| Cache lifecycle | Build and discard each time a command is executed | Resident cache (always synced via event listeners) | Resident caches are a hotbed for "cache rot". Furthermore, on mobile environments, there were concerns about battery consumption due to resident processes. |
+| Failsafe | Not implemented (rendered unnecessary by reducing complexity) | Timeout process after a certain time (5-10 seconds) | Because lookups became $O(1)$ and the search process is now completed in milliseconds, timeout processing is no longer necessary. |
+
+## Implementation
+
+`buildReverseCache()` is executed exactly once at the beginning of `findLastNote()` and similar functions that initiate a command. This builds a complete reverse lookup map in $O(E)$ time from all link information ($E$) and optimizes subsequent search processes.
+
+### Building Reverse Cache (`buildReverseCache`)
+
+It quickly iterates over `app.metadataCache.resolvedLinks` using a `for...in` syntax to create a reverse lookup map while minimizing memory allocation.
+
+```typescript
+export function buildReverseCache(app: App): Record<string, string[]> {
+  const resolvedLinks = app.metadataCache.resolvedLinks;
+  const cache: Record<string, string[]> = {};
+
+  for (const sourcePath in resolvedLinks) {
+    if (!Object.prototype.hasOwnProperty.call(resolvedLinks, sourcePath)) continue;
+
+    const targets = resolvedLinks[sourcePath];
+    for (const targetPath in targets) {
+      if (!Object.prototype.hasOwnProperty.call(targets, targetPath)) continue;
+
+      if (!cache[targetPath]) cache[targetPath] = [];
+      cache[targetPath].push(sourcePath);
+    }
+  }
+  return cache;
+}
+```
+
+### Searching for the Last Note (`findLastNote`)
+
+It rapidly searches for the end of a chain using the built reverse lookup map (`reverseCache`). Because each subsequent note search (`getNextNotesWithCache`) is processed in $O(1)$, the computational complexity of the entire loop is kept to $O(D)$.
+
+```typescript
+export async function findLastNote(app: App, startNote: TFile, placeholder: string = "Select the next branch..."): Promise<TFile | null> {
+  const reverseCache = buildReverseCache(app);
+  let lastNote = startNote;
+
+  while (true) {
+    const nextNotes = getNextNotesWithCache(app, lastNote, reverseCache);
+    if (nextNotes.length === 0 || nextNotes.includes(startNote)) {
+      break;
+    }
+
+    if (nextNotes.length === 1) {
+      // If there is 1 candidate, proceed
+      lastNote = nextNotes[0];
+    } else {
+      // If there are branches, display suggest UI
+      const selectedNote = await new Promise<TFile | null>((resolve) => {
+        new NextNoteSuggestModal(app, nextNotes, resolve, placeholder).open();
+      });
+
+      if (!selectedNote) return null;
+      lastNote = selectedNote;
+    }
+  }
+  return lastNote;
+}
+```
+
+## Use Cases
+
+Applied to processes that identify the end of deep link hierarchies in Vaults containing tens of thousands of notes.
+
+### Identifying the end of long thought chains
+
+Improves performance when identifying the end note in a chain where thousands to tens of thousands of notes are connected.
+While a cache building time of about 10-50 milliseconds occurs at runtime, subsequent node searches are processed in perfect $O(1)$ time, which prevents UI freezing (blocking).
+
+### Resource optimization in mobile environments
+
+Minimizes memory consumption in resource-constrained environments like mobile environments (iOS / Android).
+The object for the cache is built only when the command is executed and is immediately collected by GC (Garbage Collection) after the process is completed, so it does not pressure resident memory.
+
+## Commit Logs
+
+Relevant key commit history is presented below.
+
+- [`83d28c8`](https://github.com/ongaeshi/previous-river/commit/83d28c8) feat: Remove timeout
+- [`6cee7ba`](https://github.com/ongaeshi/previous-river/commit/6cee7ba) perf: Build O(1) reverse cache in findLastNote to eliminate O(V*D) overhead
+- [`02999b5`](https://github.com/ongaeshi/previous-river/commit/02999b5) perf: getNextNotes via detailed backlink properties
+- [`c68596d`](https://github.com/ongaeshi/previous-river/commit/c68596d) perf: Optimize backlink iteration in getNextNotes
+- [`21adb7d`](https://github.com/ongaeshi/previous-river/commit/21adb7d) feat: Add timeout to findLastNote search
+- [`6e8e72b`](https://github.com/ongaeshi/previous-river/commit/6e8e72b) refactor: findLastNote utility function into a `lib/obsidian.ts` module.
+- [`c6dd657`](https://github.com/ongaeshi/previous-river/commit/c6dd657) refactor: Extranct getNextNotes() function
+
+---
+[⬅️ (previous) 001_chain_algorithm](001_chain_algorithm.md) | [003_canvas_export  (next) ➡️](003_canvas_export.md)

--- a/docs/en/003_canvas_export.md
+++ b/docs/en/003_canvas_export.md
@@ -1,0 +1,124 @@
+# Design and Implementation of Canvas Export Feature in Previous River
+
+## Purpose
+
+To provide a bird's-eye view and visualization of note connections (River) established by the `previous` property.
+By exporting to the `.canvas` format, it achieves "complete control over node placement" and "giving meaning to arrow directions," which are difficult with Obsidian's standard Graph View. This allows for graphical representation of complex branching thoughts that cannot be fully grasped through text.
+
+## Terminology
+
+- **Root Note**: The starting point of a network that does not have a `previous` property (or whose reference does not exist) but is referenced as a parent by others.
+- **Isolated Cycle**: An independent graph where all notes are circularly connected by `previous` and have no root.
+- **Wrap Layout**: A layout that wraps placement to the left edge upon reaching a certain number of columns to prevent continuous, linear notes from becoming too wide horizontally.
+
+```mermaid
+graph LR
+  Root[Root Note] --> N1[Note 1]
+  N1 --> N2[Note 2]
+  N1 --> N3[Note 3]
+  
+  subgraph Isolated Cycle
+    C1[Cycle A] --> C2[Cycle B]
+    C2 --> C1
+  end
+```
+
+## Design Philosophy
+
+The following considerations were made regarding Canvas file generation and the layout algorithm.
+
+| Consideration | Adopted Idea | Rejected Idea | Reason |
+|---|---|---|---|
+| Visualization method | Direct generation of `.canvas` files | Utilizing Obsidian Graph View | Because detailed node placement and drawing control for arrow directions (parent-child relationships) are impossible in Graph View. With the Canvas format, coordinates (x, y) and connecting edges can be completely controlled by calculation. |
+| Node size | Enlarged height to `500px` | Default size | Because in the `.canvas` specification, the properties (Frontmatter) part cannot be folded by default, hiding the main text. Secured preview area for the main text. |
+| Layout method | Introduction of Wrap Layout | Simple linear placement | Because a linear placement using DFS would stretch the Canvas horizontally when chains are long, reducing visibility. Set a maximum of `MAX_COLUMNS = 5` and adopted an algorithm that wraps to the left edge while shifting the Y-coordinate upon reaching this limit. |
+| Edge direction | Drawn from parent to child (origin -> next note) | Drawn from child to parent (direction of `previous`) | Although actual internal links go "from child to parent", this was devised so that derivations of thought and the flow of time can be visually and intuitively grasped. |
+| Separation between trees | Set a Y-coordinate margin of `+1000px` between individual networks | - | To ensure different graphs do not overlap when multiple roots or chains exist. |
+
+## Implementation
+
+### Defining Data Structures
+
+Interface definitions were created in accordance with Obsidian's `.canvas` file format specification. This made it possible to describe coordinate calculations and edge connection directions in a type-safe and intuitive manner.
+
+```typescript
+export interface CanvasNode {
+  id: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  type: "file";
+  file: string;
+}
+
+export interface CanvasEdge {
+  id: string;
+  fromNode: string;
+  fromSide: "top" | "right" | "bottom" | "left";
+  toNode: string;
+  toSide: "top" | "right" | "bottom" | "left";
+}
+
+export interface CanvasData {
+  nodes: CanvasNode[];
+  edges: CanvasEdge[];
+}
+```
+
+### Layout Calculation
+
+The logic for layout calculation and Canvas generation is consolidated in the `CanvasGenerator` class. It places nodes using DFS (Depth-First Search) and incorporates circular reference prevention and wrap processing.
+
+```typescript
+class CanvasGenerator {
+  // ...
+  dfs(current: TFile, col: number, y: number, direction: number): string {
+    const existingNodeId = this.fileToNodeId.get(current.path);
+    if (existingNodeId) return existingNodeId; // Prevention of infinite loops (cycles)
+
+    // ...
+
+    let isWrapped = false;
+    if (nextCol >= this.MAX_COLUMNS) {
+      nextCol = 0; // Return to the left edge
+      nextY += yStep; // Move to the bottom row
+      if (nextY > this.maxUsedY) this.maxUsedY = nextY;
+      isWrapped = true;
+    }
+    
+    // ...
+    
+    return nodeId;
+  }
+}
+```
+
+## Command List
+
+The Previous River plugin provides the following commands related to Canvas export.
+
+| Command Name | Description |
+|---|---|
+| **Export next notes to canvas** | Export the forward (child) network starting from the current note as a Canvas file |
+| **Export all rivers to canvas** | Export connections (chains) of all notes existing in the Vault in bulk as a single Canvas file |
+| **Export filtered rivers to canvas** | Extract and export only the networks belonging to notes that match search criteria (path, tag, link, etc.) as a Canvas file |
+
+## Use Cases
+
+- **Organizing complex thoughts**: Output the connections of Zettelkasten or linked memos as a Canvas to grasp the network structure and branches from a macro perspective.
+- **Auditing the entire Vault**: Execute `Export all rivers to canvas` to find broken connections or isolated loops. This visualizes inconsistent reference structures between notes, providing clues for correction.
+- **Analyzing specific projects**: Use `Export filtered rivers to canvas` to extract only the networks of note groups belonging to a specific directory or tag. This facilitates analysis focused on specific projects or themes.
+
+## Commit Logs
+
+Relevant key commit history is presented below.
+
+- [ce6f0d3](https://github.com/ongaeshi/previous-river/commit/ce6f0d3) feat: Add command to export the next notes tree to a Canvas file
+- [9e89cc6](https://github.com/ongaeshi/previous-river/commit/9e89cc6) feat: Add command to export all connected notes to a Canvas file
+- [9432f29](https://github.com/ongaeshi/previous-river/commit/9432f29) refactor: Add confirmation dialog and extract canvas generation logic
+- [7716d36](https://github.com/ongaeshi/previous-river/commit/7716d36) style: Increase Canvas node height and adjust vertical margins
+- [511e448](https://github.com/ongaeshi/previous-river/commit/511e448) feat: Add  export-filtered-rivers-to-canvas command
+
+---
+[⬅️ (previous) 002_find_last_note_optimization](002_find_last_note_optimization.md)

--- a/lib/ExportFilterModal.ts
+++ b/lib/ExportFilterModal.ts
@@ -139,7 +139,7 @@ export class ExportFilterModal extends Modal {
                         exportAll: this.exportAll
                     };
                     lastExportFilterResult = result;
-                    this.onSubmit(result);
+                    void this.onSubmit(result);
                 }));
     }
 

--- a/lib/commands.ts
+++ b/lib/commands.ts
@@ -166,6 +166,60 @@ export async function insertNoteCommand(app: App) {
     }
 }
 
+export async function duplicateNextNoteCommand(app: App) {
+    const file = getActiveFile(app);
+    if (!file) {
+        return;
+    }
+
+    // 1. Find successors of the current note
+    const successors = getNextNotes(app, file);
+
+    let targetNextNote: TFile | null = null;
+    if (successors.length === 1) {
+        targetNextNote = successors[0];
+    } else if (successors.length > 1) {
+        targetNextNote = await new Promise<TFile | null>((resolve) => {
+            new NextNoteSuggestModal(app, successors, resolve, "Select next note...").open();
+        });
+        if (!targetNextNote) {
+            return; // cancelled
+        }
+    }
+
+    // 2. Duplicate the current note
+    const parentFolder = file.parent;
+    let parentPath = "";
+    if (parentFolder && parentFolder.path !== "/") {
+        parentPath = parentFolder.path + "/";
+    }
+    let newName = `${file.basename} 1`;
+    let newPath = `${parentPath}${newName}.${file.extension}`;
+    let counter = 1;
+    while (app.vault.getAbstractFileByPath(newPath)) {
+        counter++;
+        newName = `${file.basename} ${counter}`;
+        newPath = `${parentPath}${newName}.${file.extension}`;
+    }
+
+    const newFile = await app.vault.copy(file, newPath) as TFile;
+
+    // 3. Open the newly created note
+    await app.workspace.getLeaf().openFile(newFile);
+
+    // 4. Set the new note's previous property to the original note
+    await setPreviousProperty(app, newFile, file.basename);
+
+    // 5. If there was a targetNextNote, set its previous property to the new note
+    if (targetNextNote) {
+        await setPreviousProperty(app, targetNextNote, newFile.basename);
+        new Notice(`Duplicated note and inserted between ${file.basename} and ${targetNextNote.basename}`);
+    } else {
+        new Notice(`Duplicated note after ${file.basename}`);
+    }
+}
+
+
 export async function insertNoteToFirstCommand(app: App) {
     const file = getActiveFile(app);
     if (!file) {

--- a/lib/commands.ts
+++ b/lib/commands.ts
@@ -492,3 +492,16 @@ export function exportFilteredRiversToCanvasCommand(app: App) {
 
     }).open();
 }
+
+export async function setRootCommand(app: App) {
+    const file = getActiveFile(app);
+    if (!file) {
+        return;
+    }
+
+    await app.fileManager.processFrontMatter(file, (fm) => {
+        fm.previous = "ROOT";
+    });
+
+    new Notice(`Set ROOT to previous property of ${file.basename}`);
+}

--- a/lib/obsidian.ts
+++ b/lib/obsidian.ts
@@ -221,12 +221,7 @@ export function isAncestor(app: App, note: TFile, target: TFile): boolean {
   const visited = new Set<string>();
   visited.add(current.path);
 
-  // Limit iteration to prevent infinite loops in case of cycles (though visited set handles it)
-  // A reasonable limit for depth
-  let depth = 0;
-  const maxDepth = 100000; // TODO: Is this limit necessary?
-
-  while (depth < maxDepth) {
+  while (true) {
     const prev = getPreviousNote(app, current);
     if (!prev) {
       return false;
@@ -242,10 +237,7 @@ export function isAncestor(app: App, note: TFile, target: TFile): boolean {
 
     visited.add(prev.path);
     current = prev;
-    depth++;
   }
-
-  return false;
 }
 
 /**

--- a/main.ts
+++ b/main.ts
@@ -101,5 +101,63 @@ export default class PreviousRiverPlugin extends Plugin {
       name: "Duplicate next note",
       callback: () => duplicateNextNoteCommand(this.app),
     });
+
+    this.app.workspace.onLayoutReady(() => {
+      let timeoutId: number | null = null;
+      
+      const observer = new MutationObserver(() => {
+        if (timeoutId !== null) {
+          window.clearTimeout(timeoutId);
+        }
+        
+        timeoutId = window.setTimeout(() => {
+          const propertiesContainers = document.querySelectorAll('.metadata-properties');
+          propertiesContainers.forEach((container) => {
+            const properties = container.querySelectorAll('.metadata-property');
+            properties.forEach((property) => {
+              const keyInput = property.querySelector('.metadata-property-key-input') as HTMLInputElement | null;
+              const keyTextEl = property.querySelector('.metadata-property-key');
+              
+              let keyText = "";
+              if (keyInput && keyInput.value) {
+                keyText = keyInput.value;
+              } else if (keyTextEl && keyTextEl.textContent) {
+                keyText = keyTextEl.textContent;
+              }
+
+              if (keyText.toLowerCase() === 'previous') {
+                if (property.querySelector('.previous-river-go-next-button')) return;
+
+                const button = property.createEl('button', {
+                  text: 'Go next notes',
+                  cls: 'previous-river-go-next-button',
+                });
+
+                // Style the button slightly so it looks good inline
+                button.style.marginLeft = '8px';
+                button.style.height = 'var(--input-height)';
+                button.style.padding = '0 12px';
+
+                button.addEventListener('click', (e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  goToNextNoteCommand(this.app);
+                });
+
+                const valueContainer = property.querySelector('.metadata-property-value');
+                if (valueContainer) {
+                  valueContainer.appendChild(button);
+                } else {
+                  property.appendChild(button);
+                }
+              }
+            });
+          });
+        }, 100); // debounce slightly to avoid performance hit
+      });
+
+      observer.observe(document.body, { childList: true, subtree: true });
+      this.register(() => observer.disconnect());
+    });
   }
 }

--- a/main.ts
+++ b/main.ts
@@ -129,7 +129,7 @@ export default class PreviousRiverPlugin extends Plugin {
                 if (property.querySelector('.previous-river-go-next-button')) return;
 
                 const button = property.createEl('button', {
-                  text: 'Go next notes',
+                  text: 'next',
                   cls: 'previous-river-go-next-button',
                 });
 

--- a/main.ts
+++ b/main.ts
@@ -12,7 +12,8 @@ import {
   exportNextNotesToCanvasCommand,
   exportAllRiversToCanvasCommand,
   exportFilteredRiversToCanvasCommand,
-  setRootCommand
+  setRootCommand,
+  duplicateNextNoteCommand
 } from "./lib/commands";
 
 export default class PreviousRiverPlugin extends Plugin {
@@ -93,6 +94,12 @@ export default class PreviousRiverPlugin extends Plugin {
       id: "set-root",
       name: "Set ROOT to previous property",
       callback: () => setRootCommand(this.app),
+    });
+
+    this.addCommand({
+      id: "duplicate-next-note",
+      name: "Duplicate next note",
+      callback: () => duplicateNextNoteCommand(this.app),
     });
   }
 }

--- a/main.ts
+++ b/main.ts
@@ -133,10 +133,16 @@ export default class PreviousRiverPlugin extends Plugin {
                   cls: 'previous-river-go-next-button',
                 });
 
-                // Style the button slightly so it looks good inline
-                button.style.marginLeft = '8px';
-                button.style.height = 'var(--input-height)';
+                // Set absolute positioning to place it on the right side without affecting height
+                (property as HTMLElement).style.position = 'relative';
+                
+                button.style.position = 'absolute';
+                button.style.right = '4px';
+                button.style.top = '50%';
+                button.style.transform = 'translateY(-50%)';
+                button.style.height = '24px';
                 button.style.padding = '0 12px';
+                button.style.zIndex = '10';
 
                 button.addEventListener('click', (e) => {
                   e.preventDefault();
@@ -144,12 +150,8 @@ export default class PreviousRiverPlugin extends Plugin {
                   goToNextNoteCommand(this.app);
                 });
 
-                const valueContainer = property.querySelector('.metadata-property-value');
-                if (valueContainer) {
-                  valueContainer.appendChild(button);
-                } else {
-                  property.appendChild(button);
-                }
+                // Simply append to the property container
+                property.appendChild(button);
               }
             });
           });

--- a/main.ts
+++ b/main.ts
@@ -15,6 +15,7 @@ import {
   setRootCommand,
   duplicateNextNoteCommand
 } from "./lib/commands";
+import { getNextNotes } from "./lib/obsidian";
 
 export default class PreviousRiverPlugin extends Plugin {
   onload() {
@@ -111,6 +112,9 @@ export default class PreviousRiverPlugin extends Plugin {
         }
         
         timeoutId = window.setTimeout(() => {
+          const activeFile = this.app.workspace.getActiveFile();
+          const hasNextNotes = activeFile ? getNextNotes(this.app, activeFile).length > 0 : false;
+
           const propertiesContainers = document.querySelectorAll('.metadata-properties');
           propertiesContainers.forEach((container) => {
             const properties = container.querySelectorAll('.metadata-property');
@@ -126,7 +130,16 @@ export default class PreviousRiverPlugin extends Plugin {
               }
 
               if (keyText.toLowerCase() === 'previous') {
-                if (property.querySelector('.previous-river-go-next-button')) return;
+                const existingButton = property.querySelector('.previous-river-go-next-button');
+
+                if (!hasNextNotes) {
+                  if (existingButton) {
+                    existingButton.remove();
+                  }
+                  return;
+                }
+
+                if (existingButton) return;
 
                 const button = property.createEl('button', {
                   text: 'next',

--- a/main.ts
+++ b/main.ts
@@ -11,7 +11,8 @@ import {
   copyNextNotesListCommand,
   exportNextNotesToCanvasCommand,
   exportAllRiversToCanvasCommand,
-  exportFilteredRiversToCanvasCommand
+  exportFilteredRiversToCanvasCommand,
+  setRootCommand
 } from "./lib/commands";
 
 export default class PreviousRiverPlugin extends Plugin {
@@ -86,6 +87,12 @@ export default class PreviousRiverPlugin extends Plugin {
       id: "export-filtered-rivers-to-canvas",
       name: "Export filtered rivers to canvas",
       callback: () => exportFilteredRiversToCanvasCommand(this.app),
+    });
+
+    this.addCommand({
+      id: "set-root",
+      name: "Set ROOT to previous property",
+      callback: () => setRootCommand(this.app),
     });
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "previous-river",
 	"name": "Previous River",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"minAppVersion": "1.4.0",
 	"description": "Move between notes using 'previous' property and backlinks.",
 	"author": "ongaeshi",


### PR DESCRIPTION
- **Next button**: Add a "Next" button to the right side of the `previous` property row within Obsidian's native Properties view.
- **Duplicate next note**: Add a command to duplicate the currently active note and automatically set the new note's `previous` property to point back to the original note.
- **Set ROOT**: Add a command to quickly set the `previous` property of the active file to `ROOT`.
- **Fix floating promise lint error**: Fix a TypeScript linting error in `ExportFilterModal` by explicitly handling an unhandled promise invocation.
- **Translate technical docs**: Translate the Japanese technical documentation (`docs/ja/`) into English.