### PR TITLE
Improve canvas export and fix path resolution

### DIFF
--- a/lib/ExportFilterModal.ts
+++ b/lib/ExportFilterModal.ts
@@ -1,6 +1,7 @@
 import { App, Modal, Setting } from "obsidian";
 
 export interface ExportFilterResult {
+    filename: string;
     directory: string;
     tag: string;
     link: string;
@@ -14,6 +15,7 @@ export interface ExportFilterResult {
 let lastExportFilterResult: ExportFilterResult | null = null;
 
 export class ExportFilterModal extends Modal {
+    filename: string;
     directory: string;
     tag: string;
     link: string;
@@ -28,6 +30,7 @@ export class ExportFilterModal extends Modal {
         super(app);
         this.onSubmit = onSubmit;
         if (lastExportFilterResult) {
+            this.filename = lastExportFilterResult.filename;
             this.directory = lastExportFilterResult.directory;
             this.tag = lastExportFilterResult.tag;
             this.link = lastExportFilterResult.link;
@@ -37,6 +40,7 @@ export class ExportFilterModal extends Modal {
             this.maxColumns = lastExportFilterResult.maxColumns;
             this.exportAll = lastExportFilterResult.exportAll;
         } else {
+            this.filename = '';
             this.directory = '';
             this.tag = '';
             this.link = '';
@@ -51,6 +55,14 @@ export class ExportFilterModal extends Modal {
     onOpen() {
         const { contentEl } = this;
         contentEl.createEl("h2", { text: "Export connected notes by filter" });
+
+        const filenameSetting = new Setting(contentEl)
+            .setName("Canvas name")
+            .setDesc("Leave empty to auto-generate based on filters")
+            .addText(text => text
+                .setValue(this.filename)
+                .setPlaceholder("e.g. My Canvas")
+                .onChange(value => this.filename = value));
 
         const dirSetting = new Setting(contentEl)
             .setName("Directory")
@@ -129,6 +141,7 @@ export class ExportFilterModal extends Modal {
                 .onClick(() => {
                     this.close();
                     const result: ExportFilterResult = {
+                        filename: this.filename,
                         directory: this.directory,
                         tag: this.tag,
                         link: this.link,

--- a/lib/commands.ts
+++ b/lib/commands.ts
@@ -409,7 +409,7 @@ export function exportAllRiversToCanvasCommand(app: App) {
 
 export function exportFilteredRiversToCanvasCommand(app: App) {
     new ExportFilterModal(app, async (result) => {
-        let { directory, tag, link, property, width, height, maxColumns, exportAll } = result;
+        let { filename, directory, tag, link, property, width, height, maxColumns, exportAll } = result;
         if (!exportAll && !directory && !tag && !link) {
             new Notice("Please provide at least one filter criterion or check 'search all elements'.");
             return;
@@ -541,8 +541,28 @@ export function exportFilteredRiversToCanvasCommand(app: App) {
 
         const activeFile = getActiveFile(app);
         const sourcePath = activeFile ? activeFile.path : "";
-        const canvasName = "Filtered Connected Notes.canvas";
-        const saveDir = app.fileManager.getNewFileParent(sourcePath, "Filtered Connected Notes.md").path;
+        
+        let canvasName = filename.trim();
+        if (!canvasName) {
+            if (exportAll) {
+                canvasName = "All Filtered Connected Notes";
+            } else if (tag) {
+                canvasName = `Filtered Rivers - ${tag.replace(/^#/, '')}`;
+            } else if (directory) {
+                const dirParts = directory.split('/').filter(p => p);
+                const dirName = dirParts.length > 0 ? dirParts.pop() : directory;
+                canvasName = `Filtered Rivers - ${dirName}`;
+            } else if (link) {
+                canvasName = `Filtered Rivers - ${link}`;
+            } else {
+                canvasName = "Filtered Connected Notes";
+            }
+        }
+        if (!canvasName.endsWith(".canvas")) {
+            canvasName += ".canvas";
+        }
+
+        const saveDir = app.fileManager.getNewFileParent(sourcePath, canvasName.replace(".canvas", ".md")).path;
 
         await saveCanvasData(app, generator.nodes, generator.edges, canvasName, saveDir);
 

--- a/lib/commands.ts
+++ b/lib/commands.ts
@@ -1,7 +1,7 @@
 import { App, TFile, Notice } from "obsidian";
 import { ConfirmModal } from "./ConfirmModal";
 import { NextNoteSuggestModal } from "./NextNoteSuggestModal";
-import { getActiveFile, getPreviousNote, getNextNotes, getNextNotesWithCache, buildReverseCache, detachNote, setPreviousProperty, findLastNote, findFirstNote, isOnSamePath } from "./obsidian";
+import { getActiveFile, getPreviousNote, getNextNotes, getNextNotesWithCache, buildReverseCache, detachNote, setPreviousProperty, findLastNote, findFirstNote, isOnSamePath, hasPreviousProperty } from "./obsidian";
 import { CanvasGenerator, saveCanvasData } from "./canvas";
 import { ExportFilterModal } from "./ExportFilterModal";
 
@@ -362,7 +362,8 @@ async function generateAllRiversCanvas(app: App) {
         const prev = getPreviousNote(app, file);
         if (!prev) {
             const nexts = getNextNotesWithCache(app, file, reverseCache);
-            if (nexts.length > 0) {
+            const hasPrevProp = hasPreviousProperty(app, file);
+            if (nexts.length > 0 || hasPrevProp) {
                 generator.dfs(file, 0, currentY, 1);
                 currentY = generator.maxUsedY + 1000;
             }
@@ -502,9 +503,10 @@ export function exportFilteredRiversToCanvasCommand(app: App) {
         for (const file of matchedFiles) {
             const prev = getPreviousNote(app, file);
             const nexts = getNextNotesWithCache(app, file, reverseCache);
+            const hasPrevProp = hasPreviousProperty(app, file);
             
             // Skip isolated notes that do not belong to any river
-            if (!prev && nexts.length === 0) {
+            if (!prev && nexts.length === 0 && !hasPrevProp) {
                 continue;
             }
 

--- a/lib/obsidian.ts
+++ b/lib/obsidian.ts
@@ -85,7 +85,8 @@ export function getNextNotes(app: App, file: TFile): TFile[] {
     }
 
     // Add only if the `previous` field points to the current note.
-    if (previousLinkText === file.basename || previousLinkText === currentPath) {
+    const dest = app.metadataCache.getFirstLinkpathDest(previousLinkText, targetFile.path);
+    if (dest && dest.path === file.path) {
       nextNotes.push(targetFile);
     }
   }
@@ -167,7 +168,8 @@ export function getNextNotesWithCache(app: App, file: TFile, reverseCache: Recor
     if (!previousLinkText) continue;
 
     // Add only if the `previous` field points to the current note.
-    if (previousLinkText === file.basename || previousLinkText === currentPath) {
+    const dest = app.metadataCache.getFirstLinkpathDest(previousLinkText, targetFile.path);
+    if (dest && dest.path === file.path) {
       nextNotes.push(targetFile);
     }
   }

--- a/lib/obsidian.ts
+++ b/lib/obsidian.ts
@@ -26,6 +26,15 @@ export function getPreviousLinkpath(app: App, file: TFile): string | null {
 }
 
 /**
+ * Check if the file has a `previous` property in its frontmatter.
+ */
+export function hasPreviousProperty(app: App, file: TFile): boolean {
+  const cache = app.metadataCache.getFileCache(file);
+  const previous = cache?.frontmatter?.previous;
+  return previous !== undefined && previous !== null && previous !== "";
+}
+
+/**
  * Retrieve the previous note based on the `previous` property in the frontmatter.
  */
 export function getPreviousNote(app: App, file: TFile): TFile | null {

--- a/lib/obsidian.ts
+++ b/lib/obsidian.ts
@@ -30,8 +30,8 @@ export function getPreviousLinkpath(app: App, file: TFile): string | null {
  */
 export function hasPreviousProperty(app: App, file: TFile): boolean {
   const cache = app.metadataCache.getFileCache(file);
-  const previous = cache?.frontmatter?.previous;
-  return previous !== undefined && previous !== null && previous !== "";
+  if (!cache?.frontmatter) return false;
+  return 'previous' in cache.frontmatter;
 }
 
 /**


### PR DESCRIPTION
## Overview
This PR introduces several enhancements to the canvas export feature and fixes a bug related to path resolution.

## Changes
- **Export isolated notes**: Notes that are isolated (not linked from other notes) can now be exported to the canvas as long as they have a `previous` property.
- **Custom filename input**: Added the ability to specify a custom filename when exporting a filtered canvas.
- **Support empty `previous` property**: Notes with an empty `previous` property are now included in the export.
- **Fix path resolution (Bug fix)**: Updated `getNextNotes` and `getNextNotesWithCache` to use `app.metadataCache.getFirstLinkpathDest` instead of simple string comparisons. This ensures that folder paths are resolved correctly.